### PR TITLE
expose gutter image and color as inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "angular-split",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Angular (2+) UI library to split views using CSS flexbox layout.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/split.component.ts
+++ b/src/split.component.ts
@@ -41,7 +41,6 @@ interface Point {
         split-gutter {
             flex-grow: 0;
             flex-shrink: 0;
-            background-color: #eeeeee;
             background-position: center center;
             background-repeat: no-repeat;
         }
@@ -74,6 +73,8 @@ interface Point {
                           [order]="index*2+1"
                           [direction]="direction"
                           [size]="gutterSize"
+                          [style.background-color]="gutterColor"
+                          [image]="gutterImage"
                           [disabled]="disabled"
                           (mousedown)="startDragging($event, index*2+1)"
                           (touchstart)="startDragging($event, index*2+1)"></split-gutter>
@@ -86,6 +87,8 @@ export class SplitComponent implements OnChanges, OnDestroy {
     @Input() gutterSize: number = 10;
     @Input() disabled: boolean = false;
     @Input() visibleTransition: boolean = false;
+    @Input() gutterColor: string;
+    @Input() gutterImage: string;
 
     @Output() dragStart = new EventEmitter<Array<number>>(false);
     @Output() dragProgress = new EventEmitter<Array<number>>(false);

--- a/src/splitGutter.directive.ts
+++ b/src/splitGutter.directive.ts
@@ -27,6 +27,12 @@ export class SplitGutterDirective {
         this.refreshStyle();
     }
 
+    private _image: string;
+    @Input() set image(v: string) {
+        this._image = v;
+        this.refreshStyle();
+    }
+
     constructor(private elementRef: ElementRef,
                 private renderer: Renderer) {}
 
@@ -38,7 +44,8 @@ export class SplitGutterDirective {
 
         const state = (this._disabled === true) ? 'disabled' : this._direction;
         this.setStyle('cursor', this.getCursor(state));
-        this.setStyle('background-image', `url("${ this.getImage(state) }")`);
+
+        this.setStyle('background-image', this._image || `url("${ this.getImage(state) }")`);
     }
 
     private setStyle(key: string, value: any) {


### PR DESCRIPTION
This is a simple change. I needed to style the splitter to fit with my app's theme, so I exposed the background color and image of the gutter. They can now be set like this:

``` <split direction="horizontal" gutterColor="transparent" gutterImage="none">
or
``` <split direction="horizontal" gutterColor="#f0e3e2" gutterImage="url(https://images.com/image)">