### PR TITLE
Moves dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
         "minify": "uglifyjs dist/bundles/angular-split.umd.js --screw-ie8 --compress --mangle --comments --output dist/bundles/angular-split.umd.min.js",
         "package": "rollup -c"
     },
-
     "repository": {
         "type": "git",
         "url": "git+https://github.com/bertrandg/angular-split.git"
@@ -29,25 +28,25 @@
         "url": "https://github.com/bertrandg/angular-split/issues"
     },
     "homepage": "https://github.com/bertrandg/angular-split#readme",
-    "dependencies": {
+    "peerDependencies": {
         "@angular/common": "^4.0.0",
-        "@angular/compiler": "^4.0.0",
         "@angular/core": "^4.0.0",
-        "@angular/platform-browser": "^4.0.0",
-        "core-js": "2.4.1",
-        "rimraf": "^2.5.4",
-        "rxjs": "^5.0.2",
-        "reflect-metadata": "^0.1.3",
-        "typescript": "~2.2.0",
-        "zone.js": "^0.8.4"
+        "rxjs": "^5.0.2"
     },
     "devDependencies": {
+        "@angular/common": "^4.0.0",
+        "@angular/compiler": "^4.0.0",
         "@angular/compiler-cli": "^4.0.0",
-        "@angular/platform-server": "^4.0.0",
+        "@angular/core": "^4.0.0",
+        "@angular/platform-browser": "^4.0.0",
         "@types/jasmine": "2.2.30",
         "@types/node": "6.0.54",
         "tslint": "^3.4.0",
+        "typescript": "~2.2.0",
+        "rimraf": "^2.5.4",
         "rollup": "^0.41.4",
-        "uglify-js": "^2.7.5"
+        "rxjs": "^5.0.2",
+        "uglify-js": "^2.7.5",
+        "zone.js": "^0.8.4"
     }
 }


### PR DESCRIPTION
Due to conflicts with different versions of angular packages it would be better to have the library's dependencies declared as peerDependencies. This addresses that and only exposes the packages that are used by the library at runtime as peerDependencies.

Closes #57, #58