### PR TITLE
Switching to pageX/Y to resolve Y-coordinate inversion on mac for specific applications

### DIFF
--- a/src/components/split.component.ts
+++ b/src/components/split.component.ts
@@ -493,14 +493,14 @@ export class SplitComponent implements AfterViewInit, OnDestroy {
         let start: IPoint;
         if(startEvent instanceof MouseEvent) {
             start = {
-                x: startEvent.screenX,
-                y: startEvent.screenY,
+                x: startEvent.pageX,
+                y: startEvent.pageY,
             };
         }
         else if(startEvent instanceof TouchEvent) {
             start = {
-                x: startEvent.touches[0].screenX,
-                y: startEvent.touches[0].screenY,
+                x: startEvent.touches[0].pageX,
+                y: startEvent.touches[0].pageY,
             };
         }
         else {
@@ -528,14 +528,14 @@ export class SplitComponent implements AfterViewInit, OnDestroy {
         let end: IPoint;
         if(event instanceof MouseEvent) {
             end = {
-                x: event.screenX,
-                y: event.screenY,
+                x: event.pageX,
+                y: event.pageY,
             };
         }
         else if(event instanceof TouchEvent) {
             end = {
-                x: event.touches[0].screenX,
-                y: event.touches[0].screenY,
+                x: event.touches[0].pageX,
+                y: event.touches[0].pageY,
             };
         }
         else {


### PR DESCRIPTION
Proposing an equivalent implementation that works around an issue when this plugin is used in Adobe Panel applications (built on Chromium Embedded Platform).

The issue is that, for such applications running specifically on MacOS, `MouseEvent.screenY` returns coordinates that are inverted; up is down and down is up. This causes undesirable behavior when dragging gutters, as they move the opposite direction of the mouse drag.

`MouseEvent.pageY` provides equivalent information, and doesn't display this behavior in this (admittedly, special-case) situation.