### PR TITLE
Fix styles lost when hosting application set to ViewEncapsulation.None

### DIFF
--- a/projects/angular-split/src/lib/component/split.component.ts
+++ b/projects/angular-split/src/lib/component/split.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, ChangeDetectionStrategy, ChangeDetectorRef, Renderer2, AfterViewInit, OnDestroy, ElementRef, NgZone, ViewChildren, QueryList, EventEmitter } from '@angular/core';
+import { Component, Input, Output, ChangeDetectionStrategy, ChangeDetectorRef, Renderer2, AfterViewInit, OnDestroy, ElementRef, NgZone, ViewChildren, QueryList, EventEmitter, ViewEncapsulation } from '@angular/core';
 import { Observable, Subscriber, Subject } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 
@@ -56,6 +56,7 @@ import { getInputPositiveNumber, getInputBoolean, isUserSizesValid, getAreaMinSi
                 <div class="as-split-gutter-icon"></div>
             </div>
         </ng-template>`,
+    encapsulation: ViewEncapsulation.Emulated
 })
 export class SplitComponent implements AfterViewInit, OnDestroy {
 


### PR DESCRIPTION
In our application we default the view encapsulation to none to be able to more easily support customer skins in CSS.

```ts
platformBrowserDynamic().bootstrapModule(AppModule, [
  {
      defaultEncapsulation: ViewEncapsulation.None
  }
])
```

This causes angular-split to loose it's style. 

The included fix overrides any inherited view encapsulation at the component level.

```ts
    encapsulation: ViewEncapsulation.Emulated
```