### PR TITLE
More precise type for AngularSplitModule

### DIFF
--- a/projects/angular-split/src/lib/module.ts
+++ b/projects/angular-split/src/lib/module.ts
@@ -19,14 +19,14 @@ import { SplitAreaDirective } from './directive/splitArea.directive';
 })
 export class AngularSplitModule {
 
-    public static forRoot(): ModuleWithProviders {
+    public static forRoot(): ModuleWithProviders<AngularSplitModule> {
         return {
             ngModule: AngularSplitModule,
             providers: []
         };
     }
 
-    public static forChild(): ModuleWithProviders {
+    public static forChild(): ModuleWithProviders<AngularSplitModule> {
         return {
             ngModule: AngularSplitModule,
             providers: []


### PR DESCRIPTION
This commit adds a generic to the ModuleWithProviders type used in AngularSplitModule. This update is needed to ensure compatibility with Angular Ivy. More information can be found here: https://next.angular.io/guide/migration-module-with-providers#why-is-this-migration-necessary