### PR TITLE
export IOutputData and IOutputAreaSizes interfaces

### DIFF
--- a/projects/angular-split/src/public_api.ts
+++ b/projects/angular-split/src/public_api.ts
@@ -5,3 +5,4 @@
 export { AngularSplitModule } from './lib/module';
 export { SplitComponent } from './lib/component/split.component';
 export { SplitAreaDirective } from './lib/directive/splitArea.directive';
+export { IOutputData, IOutputAreaSizes } from './lib/interface';


### PR DESCRIPTION
Export `IOutputData` and `IOutputAreaSizes` interfaces in order to import them from `angular-split` and not from `angular-split/lib/interface`.