### PR TITLE
refactor: use 'rxjs/operators' for pipe operators

### DIFF
--- a/projects/angular-split/src/lib/split-custom-events-behavior.directive.ts
+++ b/projects/angular-split/src/lib/split-custom-events-behavior.directive.ts
@@ -9,13 +9,12 @@ import {
   fromMouseUpEvent,
   leaveNgZone,
 } from './utils'
+import { fromEvent, of } from 'rxjs'
 import {
   delay,
   filter,
-  fromEvent,
   map,
   mergeMap,
-  of,
   repeat,
   scan,
   switchMap,
@@ -23,7 +22,7 @@ import {
   takeUntil,
   tap,
   timeInterval,
-} from 'rxjs'
+} from 'rxjs/operators'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { DOCUMENT } from '@angular/common'
 

--- a/projects/angular-split/src/lib/split/split.component.ts
+++ b/projects/angular-split/src/lib/split/split.component.ts
@@ -18,12 +18,10 @@ import {
   signal,
 } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
+import { Subject, fromEvent, merge } from 'rxjs'
 import {
-  Subject,
   filter,
-  fromEvent,
   map,
-  merge,
   pairwise,
   skipWhile,
   startWith,
@@ -31,7 +29,7 @@ import {
   take,
   takeUntil,
   tap,
-} from 'rxjs'
+} from 'rxjs/operators'
 import { ANGULAR_SPLIT_DEFAULT_OPTIONS } from '../angular-split-config.token'
 import { SplitGutterDynamicInjectorDirective } from '../gutter/split-gutter-dynamic-injector.directive'
 import { SplitGutterDirective } from '../gutter/split-gutter.directive'

--- a/projects/angular-split/src/lib/utils.ts
+++ b/projects/angular-split/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { NgZone, inject, numberAttribute } from '@angular/core'
-import { Observable, filter, fromEvent, merge } from 'rxjs'
+import { Observable, fromEvent, merge } from 'rxjs'
+import { filter } from 'rxjs/operators'
 
 export interface ClientPoint {
   x: number


### PR DESCRIPTION
refactor: Use 'rxjs/operators' to import operator functions instead of 'rxjs'

